### PR TITLE
Fix possible bug on orthogonal procrustes problem solution

### DIFF
--- a/itq.py
+++ b/itq.py
@@ -47,8 +47,8 @@ def train(
     for i in range(max_iter):
         V_tilde = V @ R
         B = V_tilde.sign()
-        [U, _, VT] = torch.svd(B.t() @ V)
-        R = (VT.t() @ U.t())
+        [U, _, W] = torch.svd(B.t() @ V)
+        R = (W @ U.t())
 
     # Evaluate
     # Generate query code and retrieval code


### PR DESCRIPTION
I believe there was an additional transposition on the definition of the solution to the orthogonal procrustes problem which lead to an incorrect solution.

The output of the SVD decomposition of matrix (B^T @ V) from pytorch is of the form: U, S, W, where (B^T @ V) = U @ S @ W^T (see the documentation https://pytorch.org/docs/stable/generated/torch.svd.html).  The solution of the orthogonal procrustes problem is given by: R = W @ U^T, not, W^T @ U^T as was implemented. 

The validity of the ITQ algorithm can be verified by printing ||V @ R - B||_F^2 at the end of each iteration. This quantity should be non-increasing, which is not the case on the current implementation.